### PR TITLE
User profile show

### DIFF
--- a/app/controllers/registered/users_controller.rb
+++ b/app/controllers/registered/users_controller.rb
@@ -1,9 +1,7 @@
 class Registered::UsersController < Registered::BaseController
   def show
-    @user = current_user
   end
 
   def edit
-    @user = current_user
   end
 end

--- a/app/controllers/registered/users_controller.rb
+++ b/app/controllers/registered/users_controller.rb
@@ -1,4 +1,5 @@
 class Registered::UsersController < Registered::BaseController
   def show
+    @user = current_user
   end
 end

--- a/app/controllers/registered/users_controller.rb
+++ b/app/controllers/registered/users_controller.rb
@@ -3,5 +3,6 @@ class Registered::UsersController < Registered::BaseController
   end
 
   def edit
+    @user = current_user
   end
 end

--- a/app/controllers/registered/users_controller.rb
+++ b/app/controllers/registered/users_controller.rb
@@ -2,4 +2,8 @@ class Registered::UsersController < Registered::BaseController
   def show
     @user = current_user
   end
+
+  def edit
+    @user = current_user
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,6 +23,15 @@ class UsersController < ApplicationController
     end
   end
 
+    def update
+      @user = current_user
+      @user.update(user_params)
+      flash.notice = "Your profile has been updated"
+      redirect_to profile_path
+    end
+
+
+
   private
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
         if errors.has_key?(:email) && errors[:email].first[:error] == :taken
           flash.alert = "That email has already been taken."
           @user.email = nil
-          redirect_to profile_edit_path
+          render :'registered/users/edit'
         end
       end
     end

--- a/app/views/forms/_user.html.erb
+++ b/app/views/forms/_user.html.erb
@@ -37,5 +37,5 @@
   <%= f.password_field :password_confirmation, class: 'form-control' %>
 </div>
 
-<%= f.submit 'Register', class: 'btn btn-primary' %>
+<%= f.submit class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/forms/_user.html.erb
+++ b/app/views/forms/_user.html.erb
@@ -37,5 +37,5 @@
   <%= f.password_field :password_confirmation, class: 'form-control' %>
 </div>
 
-<%= f.submit class: 'btn btn-primary' %>
+<%= f.submit "Submit", class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/registered/users/edit.html.erb
+++ b/app/views/registered/users/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'forms/user' %>

--- a/app/views/registered/users/show.html.erb
+++ b/app/views/registered/users/show.html.erb
@@ -7,7 +7,7 @@
     <p>City: <%=  @user.city %> </p>
     <p>State: <%= @user.state %> </p>
     <p>Zip code: <%= @user.zipcode %> </p>
-    <%= link_to "Edit my profile" %>
+    <%= link_to "Edit my profile", profile_edit_path %>
   </article>
 
 </section>

--- a/app/views/registered/users/show.html.erb
+++ b/app/views/registered/users/show.html.erb
@@ -1,12 +1,12 @@
 <section>
   <h1>Your profile</h1>
   <article class="user-info">
-    <p>Username: <%= @user.name %> </p>
-    <p>Email: <%= @user.email %> </p>
-    <p>Address: <%= @user.address %> </p>
-    <p>City: <%=  @user.city %> </p>
-    <p>State: <%= @user.state %> </p>
-    <p>Zip code: <%= @user.zipcode %> </p>
+    <p>Username: <%= current_user.name %> </p>
+    <p>Email: <%= current_user.email %> </p>
+    <p>Address: <%= current_user.address %> </p>
+    <p>City: <%=  current_user.city %> </p>
+    <p>State: <%= current_user.state %> </p>
+    <p>Zip code: <%= current_user.zipcode %> </p>
     <%= link_to "Edit my profile", profile_edit_path %>
   </article>
 

--- a/app/views/registered/users/show.html.erb
+++ b/app/views/registered/users/show.html.erb
@@ -1,0 +1,13 @@
+<section>
+  <h1>Your profile</h1>
+  <article class="user-info">
+    <p>Username: <%= @user.name %> </p>
+    <p>Email: <%= @user.email %> </p>
+    <p>Address: <%= @user.address %> </p>
+    <p>City: <%=  @user.city %> </p>
+    <p>State: <%= @user.state %> </p>
+    <p>Zip code: <%= @user.zipcode %> </p>
+    <%= link_to "Edit my profile" %>
+  </article>
+
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   resources :welcome, only: :index
   resources :items, only: :index
-  resources :users, only: [:index, :create]
+  resources :users, only: [:index, :create, :update]
 
   get '/cart', to: 'cart#show'
   get '/login', to: 'sessions#new'
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   get '/admin/dashboard', to: 'admin/users#show'
   get '/register', to: 'users#new'
   get '/profile', to: 'registered/users#show'
+  get '/profile/edit', to: 'registered/users#edit'
 
   scope :profile, module: :registered, as: :profile do
     resources :orders, only: [:index]
@@ -22,4 +23,6 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :users, only: [:index]
   end
+
+
 end

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'When I click on register in the nav bar' do
         fill_in 'user[email]', with: 'johns@gmail.com'
         fill_in 'user[password]', with: 'abc123'
         fill_in 'user[password_confirmation]', with: 'abc123'
-        click_button 'Register'
+        click_button 'Submit'
 
         expect(current_path).to eq(profile_path)
 
@@ -28,7 +28,7 @@ RSpec.describe 'When I click on register in the nav bar' do
         visit register_path
 
         fill_in 'user[zipcode]', with: 'abc'
-        click_button 'Register'
+        click_button 'Submit'
 
         expect(current_path).to eq(users_path)
 
@@ -49,7 +49,7 @@ RSpec.describe 'When I click on register in the nav bar' do
         fill_in 'user[email]', with: tim.email
         fill_in 'user[password]', with: 'abc123'
         fill_in 'user[password_confirmation]', with: 'abc123'
-        click_button 'Register'
+        click_button 'Submit'
 
         expect(current_path).to eq(users_path)
         expect(page).to have_content('That email is already registered.')

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe 'User profile page' do
           expect(find_field("Password").value).to eq(nil)
 
           fill_in "Name", with: "chris123"
+
           click_button "Update User"
 
           expect(current_path).to eq(profile_path)
@@ -61,8 +62,22 @@ RSpec.describe 'User profile page' do
           expect(page).to have_content("Username: chris123")
 
         end
+
+        it 'does not allow me to enter another user\'s email ' do
+          user_2 = build(:merchant)
+          user_2.save
+
+          allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+          visit profile_path
+          click_link "Edit my profile"
+          fill_in "Email", with: user_2.email
+          click_button "Update User"
+
+          expect(current_path).to eq(profile_edit_path)
+          expect(page).to have_content("That email has already been taken.")
+        end
       end
     end
-
   end
 end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe 'User profile page' do
           fill_in "Email", with: user_2.email
           click_button "Update User"
 
-          expect(current_path).to eq(profile_edit_path)
           expect(page).to have_content("That email has already been taken.")
         end
       end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -2,22 +2,25 @@ require 'rails_helper'
 
 RSpec.describe 'User profile page' do
   context 'as a registered user' do
+    before :all do
+      User.destroy_all
+      @user = build(:user)
+      @user.save
+    end
     describe 'when I visit my profile' do
       it 'I see all of my profile data except for my password' do
-        user = build(:user)
-        user.save
-        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
 
         visit profile_path
 
-        expect(page).to have_content("Username: #{user.name}")
-        expect(page).to have_content("Email: #{user.email}")
-        expect(page).to have_content("Address: #{user.address}")
-        expect(page).to have_content("City: #{user.city}")
-        expect(page).to have_content("State: #{user.state}")
-        expect(page).to have_content("Zip code: #{user.zipcode}")
+        expect(page).to have_content("Username: #{@user.name}")
+        expect(page).to have_content("Email: #{@user.email}")
+        expect(page).to have_content("Address: #{@user.address}")
+        expect(page).to have_content("City: #{@user.city}")
+        expect(page).to have_content("State: #{@user.state}")
+        expect(page).to have_content("Zip code: #{@user.zipcode}")
 
-        expect(page).to_not have_content(user.password)
+        expect(page).to_not have_content(@user.password)
       end
 
       it 'I see a link to edit my profile data' do
@@ -30,6 +33,36 @@ RSpec.describe 'User profile page' do
         expect(page).to have_link("Edit my profile")
 
       end
+
+      describe 'and I click on Edit my profile' do
+        it 'redirects me to an edit form' do
+
+          allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+          visit profile_path
+          click_link "Edit my profile"
+
+
+          expect(current_path).to eq(profile_edit_path)
+
+          expect(find_field("Name").value).to eq(@user.name)
+          expect(find_field("Email").value).to eq(@user.email)
+          expect(find_field("City").value).to eq(@user.city)
+          expect(find_field("State").value).to eq(@user.state)
+          expect(find_field("Zipcode").value).to eq(@user.zipcode.to_s)
+          expect(find_field("Address").value).to eq(@user.address)
+          expect(find_field("Password").value).to eq(nil)
+
+          fill_in "Name", with: "chris123"
+          click_button "Update User"
+
+          expect(current_path).to eq(profile_path)
+          expect(page).to have_content("Your profile has been updated")
+          expect(page).to have_content("Username: chris123")
+
+        end
+      end
     end
+
   end
 end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'User profile page' do
+  context 'as a registered user' do
+    describe 'when I visit my profile' do
+      it 'I see all of my profile data except for my password' do
+        user = build(:user)
+        user.save
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+        visit profile_path
+
+        expect(page).to have_content("Username: #{user.name}")
+        expect(page).to have_content("Email: #{user.email}")
+        expect(page).to have_content("Address: #{user.address}")
+        expect(page).to have_content("City: #{user.city}")
+        expect(page).to have_content("State: #{user.state}")
+        expect(page).to have_content("Zip code: #{user.zipcode}")
+
+        expect(page).to_not have_content(user.password)
+      end
+
+      it 'I see a link to edit my profile data' do
+        user = build(:user)
+        user.save
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+        visit profile_path
+
+        expect(page).to have_link("Edit my profile")
+
+      end
+    end
+  end
+end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe 'User profile page' do
   context 'as a registered user' do
     before :all do
-      User.destroy_all
       @user = build(:user)
       @user.save
     end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'User profile page' do
 
           fill_in "Name", with: "chris123"
 
-          click_button "Update User"
+          click_button "Submit"
 
           expect(current_path).to eq(profile_path)
           expect(page).to have_content("Your profile has been updated")
@@ -72,7 +72,7 @@ RSpec.describe 'User profile page' do
           visit profile_path
           click_link "Edit my profile"
           fill_in "Email", with: user_2.email
-          click_button "Update User"
+          click_button "Submit"
 
           expect(page).to have_content("That email has already been taken.")
         end


### PR DESCRIPTION
As a registered user
When I visit my own profile page
Then I see all of my profile data on the page except my password
And I see a link to edit my profile data

As a registered user
When I visit my profile page
I see a link to edit my profile data
When I click on the link to edit my profile data
Then my current URI route is "/profile/edit"
I see a form like the registration page
The form contains all of my user information
The password fields are blank and can be left blank
I can change any or all of the information
When I submit the form
Then I am returned to my profile page
And I see a flash message telling me that my data is updated
And I see my updated information

Closes #57 
Closes #56 
Closes #55 