### PR TITLE
Added specs for item index, all items, info and link functionality

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,8 @@
 class ItemsController < ApplicationController
   def index
+    @items = Item.enabled_items
+  end
+
+  def show
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,4 +24,8 @@ class Item < ApplicationRecord
   validates :description,
     presence: true,
     length: {minimum: 1}
+
+  def self.enabled_items
+    Item.where(disabled: false)
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,0 +1,16 @@
+<section id="cards_wrapper">
+  <% @items.each do |item| %>
+  <div class='card' id="item-<%= item.id %>">
+    <%= link_to image_tag(item.image, class: "card-img-top", alt: "#{item.name} image"), item_path(item), id: "picture-#{item.id}" %>
+    <div class="card-body">
+      <h5 class="card-title"><%= link_to item.name, item_path(item) %></h5>
+      <h6 class="merchant-name"><%= item.user.name %></h6>
+      <p class="card-text"><%= item.description %></p>
+    </div>
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item">Current price: <%= item.price %></li>
+      <li class="list-group-item">Stock: <%= item.quantity %></li>
+    </ul>
+  </div>
+  <% end %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   resources :welcome, only: :index
-  resources :items, only: :index
+  resources :items, only: [:index, :show]
   resources :users, only: [:index, :create]
 
   get '/cart', to: 'cart#show'

--- a/spec/features/items/items_index_spec.rb
+++ b/spec/features/items/items_index_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe 'items index spec' do
+  it 'shows all items' do
+    merchant = build(:merchant)
+    merchant.save
+    item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
+    item_2 = merchant.items.create(name: "Thing 2", description: "It's another thing", image: "http://www.stickpng.com/assets/thumbs/580b585b2edbce24c47b2a2c.png", price: 1.0, quantity: 444)
+
+    visit items_path
+
+    within "#item-#{item_1.id}" do
+      expect(page).to have_content(item_1.name)
+      expect(page).to have_content(item_1.user.name)
+      expect(page).to have_content(item_1.description)
+      expect(page).to have_css("img[src*='https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png']")
+      expect(page).to have_content("Current price: #{item_1.price}")
+      expect(page).to have_content("Stock: #{item_1.quantity}")
+    end
+
+    within "#item-#{item_2.id}" do
+      expect(page).to have_content(item_2.name)
+      expect(page).to have_content(item_2.user.name)
+      expect(page).to have_content(item_2.description)
+      expect(page).to have_css("img[src*='http://www.stickpng.com/assets/thumbs/580b585b2edbce24c47b2a2c.png']")
+      expect(page).to have_content("Current price: #{item_2.price}")
+      expect(page).to have_content("Stock: #{item_2.quantity}")
+    end
+  end
+
+  it 'doesnt show disabled items' do
+    merchant = build(:merchant)
+    merchant.save
+    item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
+    item_2 = merchant.items.create(name: "Thing 2", description: "It's another thing", image: "http://www.stickpng.com/assets/thumbs/580b585b2edbce24c47b2a2c.png", price: 1.0, quantity: 444, disabled: true)
+
+    visit items_path
+
+    expect(page).to_not have_content(item_2.name)
+    expect(page).to_not have_content(item_2.description)
+    expect(page).to_not have_css("img[src*='http://www.stickpng.com/assets/thumbs/580b585b2edbce24c47b2a2c.png']")
+    expect(page).to_not have_content("Current price: #{item_2.price}")
+    expect(page).to_not have_content("Stock: #{item_2.quantity}")
+  end
+
+  it 'shows a link to an items show page' do
+    merchant = build(:merchant)
+    merchant.save
+    item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
+
+    visit items_path
+
+    within "#item-#{item_1.id}" do
+      expect(page).to have_link(item_1.name)
+    end
+    click_on "#{item_1.name}"
+
+    expect(current_path).to eq(item_path(item_1))
+  end
+
+  it 'shows an image which is a link to an items show page' do
+    merchant = build(:merchant)
+    merchant.save
+    item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
+
+    visit items_path
+
+    click_link("picture-#{item_1.id}")
+
+    expect(current_path).to eq(item_path(item_1))
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -35,5 +35,13 @@ RSpec.describe Item, type: :model do
   end
 
   describe 'class methods' do
+    it '.enabled_items' do
+      merchant = build(:merchant)
+      merchant.save
+      item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
+      item_2 = merchant.items.create(name: "Thing 2", description: "It's another thing", image: "http://www.stickpng.com/assets/thumbs/580b585b2edbce24c47b2a2c.png", price: 1.0, quantity: 444, disabled: true)
+
+      expect(Item.enabled_items).to eq([item_1])
+    end
   end
 end


### PR DESCRIPTION
As any kind of user on the system
I can visit the items catalog ("/items")
I see all items in the system except disabled items
Each item will display the following information:
- the name of the item
- a small thumbnail image for the item
- the merchant name who sells the item
- how many of the item the merchant has in stock
- the merchant's current price for the item

The item name is a link to that item's show page
The item thumbnail is a link to that item's show page

Co-authored by: Peter Lapicola <p.lapicola@gmail.com>

closes #61 