### PR TITLE
Item show page

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,5 +4,6 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :user
   has_many :order_items
+  has_many :orders, through: :order_items
 
   validates_presence_of :image
 
@@ -27,5 +28,21 @@ class Item < ApplicationRecord
 
   def self.enabled_items
     Item.where(disabled: false)
+  end
+
+  def average_fulfillment_time
+    if order_items.count > 0
+      Item.joins(:order_items)
+          .where(id: self.id, order_items: {fulfilled: true})
+          .select("avg(order_items.updated_at - order_items.created_at) as f_time")
+          .group(:id)[0]
+          .f_time
+          .to_s[0..7]
+          .split(":")
+          .zip(['hours','minutes','seconds'])
+          .join(" ")
+    else
+      "Never been ordered"
+    end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,5 +1,7 @@
 class Order < ApplicationRecord
   belongs_to :user
+  has_many :order_items
+  has_many :items, through: :order_items
 
   validates_presence_of :status
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,18 @@
+<section class="container" id="item-show-container">
+  <section class="row">
+    <section class="col-12 col-md-6 col-lg-6">
+      <%= image_tag @item.image %>
+    </section>
+    <section class="col-12 col-md-6 col-lg-6">
+      <h2><%= @item.name %></h2>
+      <h4><%= @item.user.name %></h4>
+      <p>Current Price: <%= @item.price %></p>
+      <p>Stock: <%= @item.quantity %></p>
+      <p>Average Fulfillment Time: <%= @item.average_fulfillment_time %></p>
+    </section>
+  </section>
+  <section class="row">
+    <h6>Item Description:</h6>
+    <%= @item.description %>
+  </section>
+</section>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,7 +9,7 @@
       <p>Current Price: <%= @item.price %></p>
       <p>Stock: <%= @item.quantity %></p>
       <p>Average Fulfillment Time: <%= @item.average_fulfillment_time %></p>
-      <%= link_to "Add to Shopping Cart", carts_path(item_id: @item.id) unless current_user && (current_user.admin? || current_user.merchant?) %>
+      <%= link_to "Add to Shopping Cart", cart_path(item_id: @item.id) unless current_user && (current_user.admin? || current_user.merchant?) %>
     </section>
   </section>
   <section class="row">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,6 +9,7 @@
       <p>Current Price: <%= @item.price %></p>
       <p>Stock: <%= @item.quantity %></p>
       <p>Average Fulfillment Time: <%= @item.average_fulfillment_time %></p>
+      <%= link_to "Add to Shopping Cart", carts_path(item_id: @item.id) unless current_user && (current_user.admin? || current_user.merchant?) %>
     </section>
   </section>
   <section class="row">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,7 +9,7 @@
       <p>Current Price: <%= @item.price %></p>
       <p>Stock: <%= @item.quantity %></p>
       <p>Average Fulfillment Time: <%= @item.average_fulfillment_time %></p>
-      <%= link_to "Add to Shopping Cart", cart_path(item_id: @item.id) unless current_user && (current_user.admin? || current_user.merchant?) %>
+      <%= link_to "Add to Shopping Cart", carts_path(item_id: @item.id) unless current_user && (current_user.admin? || current_user.merchant?) %>
     </section>
   </section>
   <section class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :welcome, only: :index
   resources :items, only: [:index, :show]
   resources :users, only: [:index, :create]
+  resources :carts, only: [:create]
 
   get '/cart', to: 'cart#show'
   get '/login', to: 'sessions#new'

--- a/spec/features/items/item_show_spec.rb
+++ b/spec/features/items/item_show_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'item show spec' do
+  xit 'shows the items info' do
+    merchant = build(:merchant)
+    merchant.save
+    item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
+
+    visit item_path(item_1)
+
+    save_and_open_page
+
+    expect(page).to have_content(item_1.name)
+    expect(page).to have_content(item_1.description)
+    expect(page).to have_css("img[src*='#{item_1.image}']")
+    expect(page).to have_content(item_1.user.name)
+    expect(page).to have_content("Current Price: #{item_1.price}")
+    expect(page).to have_content("Stock: #{item_1.quantity}")
+    expect(page).to have_content(item_1.average_fulfillment_time)
+  end
+end

--- a/spec/features/items/item_show_spec.rb
+++ b/spec/features/items/item_show_spec.rb
@@ -1,14 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe 'item show spec' do
-  xit 'shows the items info' do
+  it 'shows the items info' do
     merchant = build(:merchant)
     merchant.save
     item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
 
     visit item_path(item_1)
-
-    save_and_open_page
 
     expect(page).to have_content(item_1.name)
     expect(page).to have_content(item_1.description)

--- a/spec/features/items/item_show_spec.rb
+++ b/spec/features/items/item_show_spec.rb
@@ -16,4 +16,45 @@ RSpec.describe 'item show spec' do
     expect(page).to have_content("Stock: #{item_1.quantity}")
     expect(page).to have_content(item_1.average_fulfillment_time)
   end
+
+  it 'shows a link if I am a regular user or visitor to add that item to my cart' do
+    merchant = build(:merchant)
+    merchant.save
+    item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
+
+    visit item_path(item_1)
+
+    expect(page).to have_link("Add to Shopping Cart")
+
+    visit root_path
+
+    user = build(:user)
+    user.save
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit item_path(item_1)
+
+    expect(page).to have_link("Add to Shopping Cart")
+  end
+
+  it 'doesnt show a link if I am a merchant or an admin to add that item to my cart' do
+    merchant = build(:merchant)
+    merchant.save
+    item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+    visit item_path(item_1)
+
+    expect(page).to_not have_link("Add to Shopping Cart")
+
+    visit root_path
+
+    admin = build(:admin)
+    admin.save
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+    expect(page).to_not have_link("Add to Shopping Cart")
+  end
 end

--- a/spec/features/items/items_index_spec.rb
+++ b/spec/features/items/items_index_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe 'items index spec' do
   it 'doesnt show disabled items' do
     merchant = build(:merchant)
     merchant.save
-    item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
     item_2 = merchant.items.create(name: "Thing 2", description: "It's another thing", image: "http://www.stickpng.com/assets/thumbs/580b585b2edbce24c47b2a2c.png", price: 1.0, quantity: 444, disabled: true)
 
     visit items_path

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe Item, type: :model do
   end
 
   describe 'instance methods' do
+    xit '.average_fulfillment_time' do
+      merchant = build(:merchant)
+      merchant.save
+      item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
+      user = build(:user)
+      user.save
+      user.orders.create()
+      sleep 2
+
+      item_1.update(fulfilled: true)
+
+      expect(item_1.average_fulfillment_time).to eq(2000)
+    end
   end
 
   describe 'class methods' do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -28,22 +28,28 @@ RSpec.describe Item, type: :model do
 
   describe 'relationships' do
     it {should have_many :order_items}
+    it {should have_many :orders}
     it {should belong_to :user}
   end
 
   describe 'instance methods' do
-    xit '.average_fulfillment_time' do
+    it '.average_fulfillment_time' do
       merchant = build(:merchant)
       merchant.save
       item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
       user = build(:user)
       user.save
-      user.orders.create()
+      order = user.orders.create
+      order_2 = user.orders.create
+      order_item_1 = OrderItem.create(item: item_1, order: order, quantity: 2, unit_price: item_1.price)
+      order_item_2 = OrderItem.create(item: item_1, order: order_2, quantity: 3, unit_price: item_1.price)
       sleep 2
 
-      item_1.update(fulfilled: true)
+      order_item_1.update(fulfilled: true)
+      sleep 2
+      order_item_2.update(fulfilled: true)
 
-      expect(item_1.average_fulfillment_time).to eq(2000)
+      expect(item_1.average_fulfillment_time).to eq("00 hours 00 minutes 03 seconds")
     end
   end
 
@@ -52,9 +58,10 @@ RSpec.describe Item, type: :model do
       merchant = build(:merchant)
       merchant.save
       item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
-      item_2 = merchant.items.create(name: "Thing 2", description: "It's another thing", image: "http://www.stickpng.com/assets/thumbs/580b585b2edbce24c47b2a2c.png", price: 1.0, quantity: 444, disabled: true)
+      merchant.items.create(name: "Thing 2", description: "It's another thing", image: "http://www.stickpng.com/assets/thumbs/580b585b2edbce24c47b2a2c.png", price: 1.0, quantity: 444, disabled: true)
+      item_3 = merchant.items.create(name: "Thing 3", description: "It's THE thing", image: "http://www.pngmart.com/files/6/Thing-PNG-File-1.png", price: 10.0, quantity: 4)
 
-      expect(Item.enabled_items).to eq([item_1])
+      expect(Item.enabled_items).to eq([item_1, item_3])
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Order, type: :model do
 
   describe 'relationships' do
     it {should belong_to :user}
+    it {should have_many :order_items}
+    it {should have_many :items}
   end
 
   describe 'instance methods' do


### PR DESCRIPTION
As any kind of user on the system
When I visit an item's show page from the items catalog
My URI route is something like "/items/18"
I see all information for this item, including:
- the name of the item
- the description of the item
- a larger image of the item
- the merchant name who sells the item
- how many of the item the merchant has in stock
- the merchant's current price for the item
- an average amount of time it takes this merchant to fulfill this item

If I am a visitor or regular user, I also see a link to add this item to my cart

closes #59 