### PR TITLE
Item index statistics #60

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   def index
     @items = Item.enabled_items
     @top_items = Item.top_items(5)
+    @worst_items = Item.worst_items(5)
   end
 
   def show

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   def index
     @items = Item.enabled_items
+    @top_items = Item.top_items(5)
   end
 
   def show

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -28,4 +28,13 @@ class Item < ApplicationRecord
   def self.enabled_items
     Item.where(disabled: false)
   end
+
+  def self.top_items(limit)
+    Item.select(:id, :name, "SUM(order_items.quantity) as quantity")
+    .joins(:order_items)
+    .where(order_items: {fulfilled: true})
+    .group(:id)
+    .order('quantity desc')
+    .limit(limit)
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -37,4 +37,13 @@ class Item < ApplicationRecord
     .order('quantity desc')
     .limit(limit)
   end
+
+  def self.worst_items(limit)
+    Item.select(:id, :name, "SUM(order_items.quantity) as quantity")
+    .joins(:order_items)
+    .where(order_items: {fulfilled: true})
+    .group(:id)
+    .order('quantity asc')
+    .limit(limit)
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,3 +1,18 @@
+<section id="statistics-wrapper">
+  <section class="row">
+    <div class="col-12 col-md-6 col-lg-5" id="top-selling-items">
+      <h1>Top Selling Items:</h1>
+      <ul>
+        <% @top_items.each do |item| %>
+          <li><%= item.name %> Quantity <%= item.quantity %></li>
+        <% end %>
+      </ul>
+    </div>
+    <div class="col-12 col-md-6 col-lg-5" id="worst-selling-items">
+      <h1>Worst Selling Items:</h1>
+    </div>
+  </section>
+</section>
 <section id="cards_wrapper">
   <% @items.each do |item| %>
   <div class='card' id="item-<%= item.id %>">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -4,12 +4,17 @@
       <h1>Top Selling Items:</h1>
       <ul>
         <% @top_items.each do |item| %>
-          <li><%= item.name %> Quantity <%= item.quantity %></li>
+          <li><%= item.name %> Quantity: <%= item.quantity %></li>
         <% end %>
       </ul>
     </div>
     <div class="col-12 col-md-6 col-lg-5" id="worst-selling-items">
-      <h1>Worst Selling Items:</h1>
+      <h1>Least Sold Items:</h1>
+      <ul>
+        <% @worst_items.each do |item| %>
+          <li><%= item.name %> Quantity: <%= item.quantity %></li>
+        <% end %>
+      </ul>
     </div>
   </section>
 </section>

--- a/spec/features/items/items_index_spec.rb
+++ b/spec/features/items/items_index_spec.rb
@@ -71,10 +71,11 @@ RSpec.describe 'items index spec' do
   end
 
   it 'shows statistics about the most and least popular items' do
+    User.destroy_all
     merchant = build(:merchant)
     merchant.save
     user = build(:user)
-    user.save
+    user.save!
     order = user.orders.create
     item_1 = merchant.items.create(name: "Item 1", description: "Description 1", price: 1.11, quantity: 1, image: 'https://picsum.photos/200')
     item_2 = merchant.items.create(name: "Item 2", description: "Description 2", price: 2.22, quantity: 2, image: 'https://picsum.photos/200')
@@ -113,10 +114,11 @@ RSpec.describe 'items index spec' do
   end
 
   it 'only shows statistics for fulfilled items' do
+    User.destroy_all
     merchant = build(:merchant)
     merchant.save
     user = build(:user)
-    user.save
+    user.save!
     order = user.orders.create
     item_1 = merchant.items.create(name: "Item 1", description: "Description 1", price: 1.11, quantity: 1, image: 'https://picsum.photos/200')
     item_2 = merchant.items.create(name: "Item 2", description: "Description 2", price: 2.22, quantity: 2, image: 'https://picsum.photos/200')
@@ -133,9 +135,11 @@ RSpec.describe 'items index spec' do
     order_items << OrderItem.create(order: order, item: item_5, unit_price: item_5.price, quantity: 5)
     order_items << OrderItem.create(order: order, item: item_6, unit_price: item_6.price, quantity: 6)
     order_items.each {|order_item| order_item.update(fulfilled: true)}
-    OrderItem.create(order: order, item: item_7, unit_price: item_7.price, quantity: 7)
+    non_fulfilled = OrderItem.create(order: order, item: item_7, unit_price: item_7.price, quantity: 7)
 
     visit items_path
+
+    save_and_open_page
 
     within '#top-selling-items' do
       expect(page).to have_content("Top Selling Items:")
@@ -144,6 +148,7 @@ RSpec.describe 'items index spec' do
       expect(page).to have_content("#{item_4.name} Quantity: #{order_items[3].quantity}")
       expect(page).to have_content("#{item_3.name} Quantity: #{order_items[2].quantity}")
       expect(page).to have_content("#{item_2.name} Quantity: #{order_items[1].quantity}")
+      expect(page).to_not have_content("#{item_7.name} Quantity: #{non_fulfilled.quantity}")
     end
 
     within '#worst-selling-items' do
@@ -153,6 +158,7 @@ RSpec.describe 'items index spec' do
       expect(page).to have_content("#{item_3.name} Quantity: #{order_items[2].quantity}")
       expect(page).to have_content("#{item_4.name} Quantity: #{order_items[3].quantity}")
       expect(page).to have_content("#{item_5.name} Quantity: #{order_items[4].quantity}")
+      expect(page).to_not have_content("#{item_7.name} Quantity: #{non_fulfilled.quantity}")
     end
   end
 end

--- a/spec/features/items/items_index_spec.rb
+++ b/spec/features/items/items_index_spec.rb
@@ -139,8 +139,6 @@ RSpec.describe 'items index spec' do
 
     visit items_path
 
-    save_and_open_page
-
     within '#top-selling-items' do
       expect(page).to have_content("Top Selling Items:")
       expect(page).to have_content("#{item_6.name} Quantity: #{order_items[5].quantity}")

--- a/spec/features/items/items_index_spec.rb
+++ b/spec/features/items/items_index_spec.rb
@@ -69,4 +69,90 @@ RSpec.describe 'items index spec' do
 
     expect(current_path).to eq(item_path(item_1))
   end
+
+  it 'shows statistics about the most and least popular items' do
+    merchant = build(:merchant)
+    merchant.save
+    user = build(:user)
+    user.save
+    order = user.orders.create
+    item_1 = merchant.items.create(name: "Item 1", description: "Description 1", price: 1.11, quantity: 1)
+    item_2 = merchant.items.create(name: "Item 2", description: "Description 2", price: 2.22, quantity: 2)
+    item_3 = merchant.items.create(name: "Item 3", description: "Description 3", price: 3.33, quantity: 3)
+    item_4 = merchant.items.create(name: "Item 4", description: "Description 4", price: 4.44, quantity: 4)
+    item_5 = merchant.items.create(name: "Item 5", description: "Description 5", price: 5.55, quantity: 5)
+    item_6 = merchant.items.create(name: "Item 6", description: "Description 6", price: 6.66, quantity: 6)
+    order_items = []
+    order_items << OrderItem.create(order: order, item: item_1, unit_price: item_1.price, quantity: 1)
+    order_items << OrderItem.create(order: order, item: item_2, unit_price: item_2.price, quantity: 2)
+    order_items << OrderItem.create(order: order, item: item_3, unit_price: item_3.price, quantity: 3)
+    order_items << OrderItem.create(order: order, item: item_4, unit_price: item_4.price, quantity: 4)
+    order_items << OrderItem.create(order: order, item: item_5, unit_price: item_5.price, quantity: 5)
+    order_items << OrderItem.create(order: order, item: item_6, unit_price: item_6.price, quantity: 6)
+    order_items.each {|order_item| order_item.update(fulfilled: true)}
+
+    visit items_path
+
+    within '#top-selling-items' do
+      expect(page).to have_content("Top Selling Items:")
+      expect(page).to have_content("#{item_6.name} Quantity: #{order_items[5].quantity}")
+      expect(page).to have_content("#{item_5.name} Quantity: #{order_items[4].quantity}")
+      expect(page).to have_content("#{item_4.name} Quantity: #{order_items[3].quantity}")
+      expect(page).to have_content("#{item_3.name} Quantity: #{order_items[2].quantity}")
+      expect(page).to have_content("#{item_2.name} Quantity: #{order_items[1].quantity}")
+    end
+
+    within '#worst-selling-items' do
+      expect(page).to have_content("Least Sold Items:")
+      expect(page).to have_content("#{item_1.name} Quantity: #{order_items[0].quantity}")
+      expect(page).to have_content("#{item_2.name} Quantity: #{order_items[1].quantity}")
+      expect(page).to have_content("#{item_3.name} Quantity: #{order_items[2].quantity}")
+      expect(page).to have_content("#{item_4.name} Quantity: #{order_items[3].quantity}")
+      expect(page).to have_content("#{item_5.name} Quantity: #{order_items[4].quantity}")
+    end
+  end
+
+  it 'only shows statistics for fulfilled items' do
+    merchant = build(:merchant)
+    merchant.save
+    user = build(:user)
+    user.save
+    order = user.orders.create
+    item_1 = merchant.items.create(name: "Item 1", description: "Description 1", price: 1.11, quantity: 1)
+    item_2 = merchant.items.create(name: "Item 2", description: "Description 2", price: 2.22, quantity: 2)
+    item_3 = merchant.items.create(name: "Item 3", description: "Description 3", price: 3.33, quantity: 3)
+    item_4 = merchant.items.create(name: "Item 4", description: "Description 4", price: 4.44, quantity: 4)
+    item_5 = merchant.items.create(name: "Item 5", description: "Description 5", price: 5.55, quantity: 5)
+    item_6 = merchant.items.create(name: "Item 6", description: "Description 6", price: 6.66, quantity: 6)
+    item_7 = merchant.items.create(name: "Item 7", description: "Description 7", price: 7.77, quantity: 7)
+    order_items = []
+    order_items << OrderItem.create(order: order, item: item_1, unit_price: item_1.price, quantity: 1)
+    order_items << OrderItem.create(order: order, item: item_2, unit_price: item_2.price, quantity: 2)
+    order_items << OrderItem.create(order: order, item: item_3, unit_price: item_3.price, quantity: 3)
+    order_items << OrderItem.create(order: order, item: item_4, unit_price: item_4.price, quantity: 4)
+    order_items << OrderItem.create(order: order, item: item_5, unit_price: item_5.price, quantity: 5)
+    order_items << OrderItem.create(order: order, item: item_6, unit_price: item_6.price, quantity: 6)
+    order_items.each {|order_item| order_item.update(fulfilled: true)}
+    OrderItem.create(order: order, item: item_7, unit_price: item_7.price, quantity: 7)
+
+    visit items_path
+
+    within '#top-selling-items' do
+      expect(page).to have_content("Top Selling Items:")
+      expect(page).to have_content("#{item_6.name} Quantity: #{order_items[5].quantity}")
+      expect(page).to have_content("#{item_5.name} Quantity: #{order_items[4].quantity}")
+      expect(page).to have_content("#{item_4.name} Quantity: #{order_items[3].quantity}")
+      expect(page).to have_content("#{item_3.name} Quantity: #{order_items[2].quantity}")
+      expect(page).to have_content("#{item_2.name} Quantity: #{order_items[1].quantity}")
+    end
+
+    within '#worst-selling-items' do
+      expect(page).to have_content("Least Sold Items:")
+      expect(page).to have_content("#{item_1.name} Quantity: #{order_items[0].quantity}")
+      expect(page).to have_content("#{item_2.name} Quantity: #{order_items[1].quantity}")
+      expect(page).to have_content("#{item_3.name} Quantity: #{order_items[2].quantity}")
+      expect(page).to have_content("#{item_4.name} Quantity: #{order_items[3].quantity}")
+      expect(page).to have_content("#{item_5.name} Quantity: #{order_items[4].quantity}")
+    end
+  end
 end

--- a/spec/features/items/items_index_spec.rb
+++ b/spec/features/items/items_index_spec.rb
@@ -76,12 +76,12 @@ RSpec.describe 'items index spec' do
     user = build(:user)
     user.save
     order = user.orders.create
-    item_1 = merchant.items.create(name: "Item 1", description: "Description 1", price: 1.11, quantity: 1)
-    item_2 = merchant.items.create(name: "Item 2", description: "Description 2", price: 2.22, quantity: 2)
-    item_3 = merchant.items.create(name: "Item 3", description: "Description 3", price: 3.33, quantity: 3)
-    item_4 = merchant.items.create(name: "Item 4", description: "Description 4", price: 4.44, quantity: 4)
-    item_5 = merchant.items.create(name: "Item 5", description: "Description 5", price: 5.55, quantity: 5)
-    item_6 = merchant.items.create(name: "Item 6", description: "Description 6", price: 6.66, quantity: 6)
+    item_1 = merchant.items.create(name: "Item 1", description: "Description 1", price: 1.11, quantity: 1, image: 'https://picsum.photos/200')
+    item_2 = merchant.items.create(name: "Item 2", description: "Description 2", price: 2.22, quantity: 2, image: 'https://picsum.photos/200')
+    item_3 = merchant.items.create(name: "Item 3", description: "Description 3", price: 3.33, quantity: 3, image: 'https://picsum.photos/200')
+    item_4 = merchant.items.create(name: "Item 4", description: "Description 4", price: 4.44, quantity: 4, image: 'https://picsum.photos/200')
+    item_5 = merchant.items.create(name: "Item 5", description: "Description 5", price: 5.55, quantity: 5, image: 'https://picsum.photos/200')
+    item_6 = merchant.items.create(name: "Item 6", description: "Description 6", price: 6.66, quantity: 6, image: 'https://picsum.photos/200')
     order_items = []
     order_items << OrderItem.create(order: order, item: item_1, unit_price: item_1.price, quantity: 1)
     order_items << OrderItem.create(order: order, item: item_2, unit_price: item_2.price, quantity: 2)
@@ -118,13 +118,13 @@ RSpec.describe 'items index spec' do
     user = build(:user)
     user.save
     order = user.orders.create
-    item_1 = merchant.items.create(name: "Item 1", description: "Description 1", price: 1.11, quantity: 1)
-    item_2 = merchant.items.create(name: "Item 2", description: "Description 2", price: 2.22, quantity: 2)
-    item_3 = merchant.items.create(name: "Item 3", description: "Description 3", price: 3.33, quantity: 3)
-    item_4 = merchant.items.create(name: "Item 4", description: "Description 4", price: 4.44, quantity: 4)
-    item_5 = merchant.items.create(name: "Item 5", description: "Description 5", price: 5.55, quantity: 5)
-    item_6 = merchant.items.create(name: "Item 6", description: "Description 6", price: 6.66, quantity: 6)
-    item_7 = merchant.items.create(name: "Item 7", description: "Description 7", price: 7.77, quantity: 7)
+    item_1 = merchant.items.create(name: "Item 1", description: "Description 1", price: 1.11, quantity: 1, image: 'https://picsum.photos/200')
+    item_2 = merchant.items.create(name: "Item 2", description: "Description 2", price: 2.22, quantity: 2, image: 'https://picsum.photos/200')
+    item_3 = merchant.items.create(name: "Item 3", description: "Description 3", price: 3.33, quantity: 3, image: 'https://picsum.photos/200')
+    item_4 = merchant.items.create(name: "Item 4", description: "Description 4", price: 4.44, quantity: 4, image: 'https://picsum.photos/200')
+    item_5 = merchant.items.create(name: "Item 5", description: "Description 5", price: 5.55, quantity: 5, image: 'https://picsum.photos/200')
+    item_6 = merchant.items.create(name: "Item 6", description: "Description 6", price: 6.66, quantity: 6, image: 'https://picsum.photos/200')
+    item_7 = merchant.items.create(name: "Item 7", description: "Description 7", price: 7.77, quantity: 7, image: 'https://picsum.photos/200')
     order_items = []
     order_items << OrderItem.create(order: order, item: item_1, unit_price: item_1.price, quantity: 1)
     order_items << OrderItem.create(order: order, item: item_2, unit_price: item_2.price, quantity: 2)

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -71,5 +71,33 @@ RSpec.describe Item, type: :model do
       expect([top_items[3].name, top_items[3].quantity]).to eq([item_2.name, order_items[1].quantity])
       expect([top_items[4].name, top_items[4].quantity]).to eq([item_1.name, order_items[0].quantity])
     end
+
+    it 'worst_items' do
+      merchant = build(:merchant)
+      merchant.save
+      user = build(:user)
+      user.save
+      order = user.orders.create
+      item_1 = merchant.items.create!(name: "Item 1", description: "Description 1", price: 1.11, quantity: 10, image: "test.png")
+      item_2 = merchant.items.create(name: "Item 2", description: "Description 2", price: 2.22, quantity: 10, image: "test.png")
+      item_3 = merchant.items.create(name: "Item 3", description: "Description 3", price: 3.33, quantity: 10, image: "test.png")
+      item_4 = merchant.items.create(name: "Item 4", description: "Description 4", price: 4.44, quantity: 10, image: "test.png")
+      item_5 = merchant.items.create(name: "Item 5", description: "Description 5", price: 5.55, quantity: 10, image: "test.png")
+      order_items = []
+      order_items << OrderItem.create(order: order, item: item_1, unit_price: item_1.price, quantity: 1)
+      order_items << OrderItem.create(order: order, item: item_2, unit_price: item_2.price, quantity: 2)
+      order_items << OrderItem.create(order: order, item: item_3, unit_price: item_3.price, quantity: 3)
+      order_items << OrderItem.create(order: order, item: item_4, unit_price: item_4.price, quantity: 4)
+      order_items << OrderItem.create(order: order, item: item_5, unit_price: item_5.price, quantity: 5)
+      order_items.each {|order_item| order_item.update(fulfilled: true)}
+
+      top_items = Item.worst_items(5)
+
+      expect([top_items[0].name, top_items[0].quantity]).to eq([item_1.name, order_items[0].quantity])
+      expect([top_items[1].name, top_items[1].quantity]).to eq([item_2.name, order_items[1].quantity])
+      expect([top_items[2].name, top_items[2].quantity]).to eq([item_3.name, order_items[2].quantity])
+      expect([top_items[3].name, top_items[3].quantity]).to eq([item_4.name, order_items[3].quantity])
+      expect([top_items[4].name, top_items[4].quantity]).to eq([item_5.name, order_items[4].quantity])
+    end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -64,7 +64,6 @@ RSpec.describe Item, type: :model do
       order_items.each {|order_item| order_item.update(fulfilled: true)}
 
       top_items = Item.top_items(5)
-      binding.pry
 
       expect([top_items[0].name, top_items[0].quantity]).to eq([item_5.name, order_items[4].quantity])
       expect([top_items[1].name, top_items[1].quantity]).to eq([item_4.name, order_items[3].quantity])

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -43,5 +43,33 @@ RSpec.describe Item, type: :model do
 
       expect(Item.enabled_items).to eq([item_1])
     end
+
+    it 'top_items' do
+      merchant = build(:merchant)
+      merchant.save
+      user = build(:user)
+      user.save
+      order = user.orders.create
+      item_1 = merchant.items.create(name: "Item 1", description: "Description 1", price: 1.11, quantity: 10)
+      item_2 = merchant.items.create(name: "Item 2", description: "Description 2", price: 2.22, quantity: 10)
+      item_3 = merchant.items.create(name: "Item 3", description: "Description 3", price: 3.33, quantity: 10)
+      item_4 = merchant.items.create(name: "Item 4", description: "Description 4", price: 4.44, quantity: 10)
+      item_5 = merchant.items.create(name: "Item 5", description: "Description 5", price: 5.55, quantity: 10)
+      order_items = []
+      order_items << OrderItem.create(order: order, item: item_1, unit_price: item_1.price, quantity: 1)
+      order_items << OrderItem.create(order: order, item: item_2, unit_price: item_2.price, quantity: 2)
+      order_items << OrderItem.create(order: order, item: item_3, unit_price: item_3.price, quantity: 3)
+      order_items << OrderItem.create(order: order, item: item_4, unit_price: item_4.price, quantity: 4)
+      order_items << OrderItem.create(order: order, item: item_5, unit_price: item_5.price, quantity: 5)
+      order_items.each {|order_item| order_item.update(fulfilled: true)}
+
+      top_items = Item.top_items(5)
+
+      expect(top_items[0].name, top_items[0].quantity).to eq(item_5.name, order_items[4].quantity)
+      expect(top_items[1].name, top_items[1].quantity).to eq(item_4.name, order_items[3].quantity)
+      expect(top_items[2].name, top_items[2].quantity).to eq(item_3.name, order_items[2].quantity)
+      expect(top_items[3].name, top_items[3].quantity).to eq(item_2.name, order_items[1].quantity)
+      expect(top_items[4].name, top_items[4].quantity).to eq(item_1.name, order_items[0].quantity)
+    end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -50,11 +50,11 @@ RSpec.describe Item, type: :model do
       user = build(:user)
       user.save
       order = user.orders.create
-      item_1 = merchant.items.create(name: "Item 1", description: "Description 1", price: 1.11, quantity: 10)
-      item_2 = merchant.items.create(name: "Item 2", description: "Description 2", price: 2.22, quantity: 10)
-      item_3 = merchant.items.create(name: "Item 3", description: "Description 3", price: 3.33, quantity: 10)
-      item_4 = merchant.items.create(name: "Item 4", description: "Description 4", price: 4.44, quantity: 10)
-      item_5 = merchant.items.create(name: "Item 5", description: "Description 5", price: 5.55, quantity: 10)
+      item_1 = merchant.items.create!(name: "Item 1", description: "Description 1", price: 1.11, quantity: 10, image: "test.png")
+      item_2 = merchant.items.create(name: "Item 2", description: "Description 2", price: 2.22, quantity: 10, image: "test.png")
+      item_3 = merchant.items.create(name: "Item 3", description: "Description 3", price: 3.33, quantity: 10, image: "test.png")
+      item_4 = merchant.items.create(name: "Item 4", description: "Description 4", price: 4.44, quantity: 10, image: "test.png")
+      item_5 = merchant.items.create(name: "Item 5", description: "Description 5", price: 5.55, quantity: 10, image: "test.png")
       order_items = []
       order_items << OrderItem.create(order: order, item: item_1, unit_price: item_1.price, quantity: 1)
       order_items << OrderItem.create(order: order, item: item_2, unit_price: item_2.price, quantity: 2)
@@ -64,12 +64,13 @@ RSpec.describe Item, type: :model do
       order_items.each {|order_item| order_item.update(fulfilled: true)}
 
       top_items = Item.top_items(5)
+      binding.pry
 
-      expect(top_items[0].name, top_items[0].quantity).to eq(item_5.name, order_items[4].quantity)
-      expect(top_items[1].name, top_items[1].quantity).to eq(item_4.name, order_items[3].quantity)
-      expect(top_items[2].name, top_items[2].quantity).to eq(item_3.name, order_items[2].quantity)
-      expect(top_items[3].name, top_items[3].quantity).to eq(item_2.name, order_items[1].quantity)
-      expect(top_items[4].name, top_items[4].quantity).to eq(item_1.name, order_items[0].quantity)
+      expect([top_items[0].name, top_items[0].quantity]).to eq([item_5.name, order_items[4].quantity])
+      expect([top_items[1].name, top_items[1].quantity]).to eq([item_4.name, order_items[3].quantity])
+      expect([top_items[2].name, top_items[2].quantity]).to eq([item_3.name, order_items[2].quantity])
+      expect([top_items[3].name, top_items[3].quantity]).to eq([item_2.name, order_items[1].quantity])
+      expect([top_items[4].name, top_items[4].quantity]).to eq([item_1.name, order_items[0].quantity])
     end
   end
 end


### PR DESCRIPTION
- Adds tests to item index spec for presence of statistics area
- Adds test for item index statistics non-inclusion of unfulfilled orders
- Adds tests for Item::top_items to retrieve top sold items by volume
- Adds tests for Item::worst_items to retrieve least sold items by volume
- Adds statistics to item show page
- Adds Item::top_items method
- Adds Item::worst_items method
- Adds a destroy_all for users to temporarily circumvent database cleaning issue between test runs
- Closes #60 