### PR TITLE
Merchant items index #18

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -1,0 +1,4 @@
+class Merchant::ItemsController < Merchant::BaseController
+  def index
+  end
+end

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -1,4 +1,5 @@
 class Merchant::ItemsController < Merchant::BaseController
   def index
+    @items = current_user.items
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -58,4 +58,8 @@ class Item < ApplicationRecord
       "Never been ordered"
     end
   end
+
+  def ordered?
+    order_items.count > 0
+  end
 end

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -3,7 +3,7 @@
   <section class="row">
     <% @items.each do |item| %>
     <div class='card col-12 col-md-6 col-lg-4 col-xl-3' id="item-<%= item.id %>">
-      <%= link_to image_tag(item.image, class: "card-img-top", alt: "#{item.name} image"), item_path(item), id: "picture-#{item.id}" %>
+      <%= image_tag(item.image, class: "card-img-top", alt: "#{item.name} image") %>
       <div class="card-body">
         <h5 class="card-title">Item #<%= item.id %> <%= item.name %></h5>
         <p class="card-text"><%= item.description %></p>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -12,9 +12,9 @@
         <li class="list-group-item">Price: <%= number_to_currency(item.price) %></li>
         <li class="list-group-item">Current Stock: <%= item.quantity %></li>
         <li class="list-group-item"><%= link_to "Edit Item", edit_merchant_item_path(item) %></li>
-        <li class="list-group-item"><%= button_to "Delete Item", merchant_item_path(item), method: :delete if !item.ordered? %></li>
-        <li class="list-group-item"><%= button_to "Enable Item", merchant_enable_item_path(item), method: :put if item.ordered? && item.disabled %></li>
-        <li class="list-group-item"><%= button_to "Disable Item", merchant_disable_item_path(item), method: :put if item.ordered? && !item.disabled %></li>
+        <li class="list-group-item"><%= button_to "Delete Item", merchant_item_path(item), method: :delete if !item.ordered? %>
+        <%= button_to "Enable Item", merchant_enable_item_path(item), method: :put if item.ordered? && item.disabled %>
+        <%= button_to "Disable Item", merchant_disable_item_path(item), method: :put if item.ordered? && !item.disabled %></li>
       </ul>
     </div>
     <% end %>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -1,0 +1,9 @@
+<section class="container">
+  <section class="row">
+    <% @items.each do |item| %>
+      <article class="row" id="item-<%= item.id %>">
+        <h3>Item #: <%= item.id %> <%= item.name %></h3>
+      </article>
+    <% end %>
+  </section>
+</section>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -1,9 +1,21 @@
 <section class="container">
   <section class="row">
     <% @items.each do |item| %>
-      <article class="row" id="item-<%= item.id %>">
-        <h3>Item #: <%= item.id %> <%= item.name %></h3>
-      </article>
+    <div class='card col-12 col-md-6 col-lg-4 col-xl-3' id="item-<%= item.id %>">
+      <%= link_to image_tag(item.image, class: "card-img-top", alt: "#{item.name} image"), item_path(item), id: "picture-#{item.id}" %>
+      <div class="card-body">
+        <h5 class="card-title">Item #<%= item.id %> <%= item.name %></h5>
+        <p class="card-text"><%= item.description %></p>
+      </div>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">Price: <%= number_to_currency(item.price) %></li>
+        <li class="list-group-item">Current Stock: <%= item.quantity %></li>
+        <li class="list-group-item"><%= link_to "Edit Item", edit_merchant_item_path(item) %></li>
+        <li class="list-group-item"><%= button_to "Delete Item", edit_merchant_item_path(item) %></li>
+        <li class="list-group-item"><%= button_to "Enable Item", edit_merchant_item_path(item) %></li>
+        <li class="list-group-item"><%= button_to "Disable Item", edit_merchant_item_path(item) %></li>
+      </ul>
+    </div>
     <% end %>
   </section>
 </section>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -11,9 +11,9 @@
         <li class="list-group-item">Price: <%= number_to_currency(item.price) %></li>
         <li class="list-group-item">Current Stock: <%= item.quantity %></li>
         <li class="list-group-item"><%= link_to "Edit Item", edit_merchant_item_path(item) %></li>
-        <li class="list-group-item"><%= button_to "Delete Item", edit_merchant_item_path(item) %></li>
-        <li class="list-group-item"><%= button_to "Enable Item", edit_merchant_item_path(item) %></li>
-        <li class="list-group-item"><%= button_to "Disable Item", edit_merchant_item_path(item) %></li>
+        <li class="list-group-item"><%= button_to "Delete Item", merchant_item_path(item), method: :delete if !item.ordered? %></li>
+        <li class="list-group-item"><%= button_to "Enable Item", merchant_enable_item_path(item), method: :put if item.ordered && item.disabled %></li>
+        <li class="list-group-item"><%= button_to "Disable Item", merchant_disable_item_path(item), method: :put if item.ordered && !item.disabled %></li>
       </ul>
     </div>
     <% end %>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -1,3 +1,4 @@
+<%= link_to "Add a new item", new_merchant_item_path %>
 <section class="container">
   <section class="row">
     <% @items.each do |item| %>
@@ -12,8 +13,8 @@
         <li class="list-group-item">Current Stock: <%= item.quantity %></li>
         <li class="list-group-item"><%= link_to "Edit Item", edit_merchant_item_path(item) %></li>
         <li class="list-group-item"><%= button_to "Delete Item", merchant_item_path(item), method: :delete if !item.ordered? %></li>
-        <li class="list-group-item"><%= button_to "Enable Item", merchant_enable_item_path(item), method: :put if item.ordered && item.disabled %></li>
-        <li class="list-group-item"><%= button_to "Disable Item", merchant_disable_item_path(item), method: :put if item.ordered && !item.disabled %></li>
+        <li class="list-group-item"><%= button_to "Enable Item", merchant_enable_item_path(item), method: :put if item.ordered? && item.disabled %></li>
+        <li class="list-group-item"><%= button_to "Disable Item", merchant_disable_item_path(item), method: :put if item.ordered? && !item.disabled %></li>
       </ul>
     </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,9 +11,16 @@ Rails.application.routes.draw do
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   get '/logout', to: 'sessions#destroy'
-  get '/dashboard', to: 'merchant/users#show'
   get '/register', to: 'users#new'
   get '/merchants', to: 'users#index'
+
+  scope :dashboard, as: :dashboard do
+    get '/', to: 'merchant/users#show'
+  end
+
+  namespace :merchant do
+    resources :items, only: [:index, :new, :create]
+  end
 
   scope :profile, as: :profile do
     resources :orders, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   end
 
   namespace :merchant do
-    resources :items, only: [:index, :new, :create]
+    resources :items, only: [:index, :new, :create, :edit, :update]
   end
 
   scope :profile, as: :profile do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
 
   namespace :merchant do
     resources :items, only: [:index, :new, :create, :edit, :update]
+    put '/items/:id/enable', to: 'items#enable', as: :enable_item
+    put '/items/:id/disable', to: 'items#disable', as: :disable_item
   end
 
   scope :profile, as: :profile do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,10 +16,11 @@ Rails.application.routes.draw do
 
   scope :dashboard, as: :dashboard do
     get '/', to: 'merchant/users#show'
+    get '/items', to: 'merchant/items#index'
   end
 
   namespace :merchant do
-    resources :items, except: [:show]
+    resources :items, except: [:show, :index]
     put '/items/:id/enable', to: 'items#enable', as: :enable_item
     put '/items/:id/disable', to: 'items#disable', as: :disable_item
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   end
 
   namespace :merchant do
-    resources :items, only: [:index, :new, :create, :edit, :update]
+    resources :items, except: [:show]
     put '/items/:id/enable', to: 'items#enable', as: :enable_item
     put '/items/:id/disable', to: 'items#disable', as: :disable_item
   end

--- a/spec/features/merchants/items/merchant_item_index_spec.rb
+++ b/spec/features/merchants/items/merchant_item_index_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'when I visit /merchants/items' do
     end
 
     it 'I see each item I have already added to the system' do
+      other_merchant_item = create(:item)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
       visit merchant_items_path
 
@@ -32,6 +33,7 @@ RSpec.describe 'when I visit /merchants/items' do
           expect(page).to have_content("Current Stock: #{item.quantity}")
         end
       end
+      expect(page).to_not have_css("#item-#{other_merchant_item.id}")
     end
 
     it 'I see a link to edit each of my items' do

--- a/spec/features/merchants/items/merchant_item_index_spec.rb
+++ b/spec/features/merchants/items/merchant_item_index_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe 'when I visit /merchants/items' do
+  context 'as a merchant' do
+    before :each do
+      @merchant = create(:merchant)
+      @merchant.items = create_list(:item, 4)
+      @enabled_items = @merchant.items
+      @merchant.items << create(:inactive_item)
+      @disabled_item = @merchant.items.last
+    end
+    it 'I see a link to add a new item' do
+      visit merchant_items_path
+
+      expect(page).to have_link("Add a new item")
+    end
+
+    it 'I see each item I have already added to the system' do
+      visit merchant_items_path
+
+      @merchant.items.each do |item|
+        within "#item-#{item.id}" do
+          expect(page).to have_content("Item ##{item.id}")
+          expect(page).to have_content(item.name)
+          expect(page).to have_css("img[src*='#{item.image}']")
+          expect(page).to have_content("Price: #{item.price.round(2)}")
+          expect(page).to have_content("Current Stock: #{item.quantity}")
+        end
+      end
+    end
+
+    it 'I see a link to edit each of my items' do
+      visit merchant_items_path
+
+      @merchant.items.each do |item|
+        within "#item-#{item.id}" do
+          expect(page).to have_link("Edit Item")
+        end
+      end
+    end
+
+    it 'I see a button to delete an unordered item' do
+      visit merchant_items_path
+
+      within "#item-#{@enabled_items.first.id}" do
+        expect(page).to have_button("Delete Item")
+      end
+    end
+
+    it 'I see a button to disable an enabled and ordered item' do
+      enabled_ordered_item = create(:order_item)
+      enabled_ordered_item.item = @enabled_items.first
+
+      visit merchant_items_path
+
+      within "#item-#{enabled_ordered_item.id}" do
+        expect(page).to have_button("Disable Item")
+      end
+    end
+
+    it 'I see a button to enable a disabled and ordered item' do
+      disabled_ordered_item = create(:order_item)
+      disabled_ordered_item.item = @disabled_item
+
+      visit merchant_items_path
+
+      within "#item-#{disabled_ordered_item.id}" do
+        expect(page).to have_button("Enable Item")
+      end
+    end
+  end
+end

--- a/spec/features/merchants/items/merchant_item_index_spec.rb
+++ b/spec/features/merchants/items/merchant_item_index_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+include ActionView::Helpers::NumberHelper
+
 RSpec.describe 'when I visit /merchants/items' do
   context 'as a merchant' do
     before :each do
@@ -26,7 +28,7 @@ RSpec.describe 'when I visit /merchants/items' do
           expect(page).to have_content("Item ##{item.id}")
           expect(page).to have_content(item.name)
           expect(page).to have_css("img[src*='#{item.image}']")
-          expect(page).to have_content("Price: #{item.price.round(2)}")
+          expect(page).to have_content("Price: #{number_to_currency(item.price)}")
           expect(page).to have_content("Current Stock: #{item.quantity}")
         end
       end

--- a/spec/features/merchants/items/merchant_item_index_spec.rb
+++ b/spec/features/merchants/items/merchant_item_index_spec.rb
@@ -56,24 +56,24 @@ RSpec.describe 'when I visit /merchants/items' do
 
     it 'I see a button to disable an enabled and ordered item' do
       enabled_ordered_item = create(:order_item)
-      enabled_ordered_item.item = @enabled_items.first
+      enabled_ordered_item.update(item: @enabled_items.first)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
 
       visit merchant_items_path
 
-      within "#item-#{enabled_ordered_item.id}" do
+      within "#item-#{@enabled_items.first.id}" do
         expect(page).to have_button("Disable Item")
       end
     end
 
     it 'I see a button to enable a disabled and ordered item' do
       disabled_ordered_item = create(:order_item)
-      disabled_ordered_item.item = @disabled_item
+      disabled_ordered_item.update(item: @disabled_item)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
 
       visit merchant_items_path
 
-      within "#item-#{disabled_ordered_item.id}" do
+      within "#item-#{@disabled_item.id}" do
         expect(page).to have_button("Enable Item")
       end
     end

--- a/spec/features/merchants/items/merchant_item_index_spec.rb
+++ b/spec/features/merchants/items/merchant_item_index_spec.rb
@@ -10,13 +10,16 @@ RSpec.describe 'when I visit /merchants/items' do
       @disabled_item = @merchant.items.last
     end
     it 'I see a link to add a new item' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
       visit merchant_items_path
 
       expect(page).to have_link("Add a new item")
     end
 
     it 'I see each item I have already added to the system' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
       visit merchant_items_path
+
 
       @merchant.items.each do |item|
         within "#item-#{item.id}" do
@@ -30,6 +33,7 @@ RSpec.describe 'when I visit /merchants/items' do
     end
 
     it 'I see a link to edit each of my items' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
       visit merchant_items_path
 
       @merchant.items.each do |item|
@@ -40,6 +44,7 @@ RSpec.describe 'when I visit /merchants/items' do
     end
 
     it 'I see a button to delete an unordered item' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
       visit merchant_items_path
 
       within "#item-#{@enabled_items.first.id}" do
@@ -50,6 +55,7 @@ RSpec.describe 'when I visit /merchants/items' do
     it 'I see a button to disable an enabled and ordered item' do
       enabled_ordered_item = create(:order_item)
       enabled_ordered_item.item = @enabled_items.first
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
 
       visit merchant_items_path
 
@@ -61,6 +67,7 @@ RSpec.describe 'when I visit /merchants/items' do
     it 'I see a button to enable a disabled and ordered item' do
       disabled_ordered_item = create(:order_item)
       disabled_ordered_item.item = @disabled_item
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
 
       visit merchant_items_path
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe Item, type: :model do
       expect(item_1.average_fulfillment_time[0..7]).to eq("00:00:03")
       expect(item_2.average_fulfillment_time).to eq("Never been ordered")
     end
+
+    it '.ordered?' do
+      ordered_item = create(:item)
+      unordered_item = create(:item)
+      create(:order_item).item = ordered_item
+
+      expect(ordered_item.ordered?).to equal(true)
+      expect(unordered_item.ordered?).to equal(false)
+    end
   end
 
   describe 'class methods' do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Item, type: :model do
     it '.ordered?' do
       ordered_item = create(:item)
       unordered_item = create(:item)
-      create(:order_item).item = ordered_item
+      create(:order_item).update(item: ordered_item)
 
       expect(ordered_item.ordered?).to equal(true)
       expect(unordered_item.ordered?).to equal(false)


### PR DESCRIPTION
- Adds tests for merchant items index page ('/dashboard/items')
- Adds test for Item#ordered? instance method to determine if an item has been ordered
- Adds Item#ordered method
- Adds merchant items index page with basic bootstrap styling present
- Adds routing for merchant item crud actions except show
- Routing for specific enable and disable actions mirroring Admin routes used for item enabling and disabling routes.
closes #18 