### PR TITLE
Admin merchant status

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -24,18 +24,25 @@ class Admin::UsersController < Admin::BaseController
 
 
   def enable
-    User.find(params[:id]).update(disabled: false)
+    @user = User.find(params[:id])
+    @user.update(disabled: false)
     flash[:primary] = 'You have enabled a user'
-    redirect_to admin_users_path
+    redirect_helper
   end
 
   def disable
-    User.find(params[:id]).update(disabled: true)
+    @user = User.find(params[:id])
+    @user.update(disabled: true)
     flash[:primary] = 'You have disabled a user'
-    redirect_to admin_users_path
+    redirect_helper
   end
 
   private
+
+  def redirect_helper
+    redirect_to admin_users_path if @user.role == 'registered'
+    redirect_to merchants_path if @user.role == 'merchant'
+  end
 
   def user_params
     strong_params = params.require(:user).permit(:name, :address, :city, :state, :zipcode, :email, :password, :password_confirmation)

--- a/spec/features/merchants/items/merchant_item_index_spec.rb
+++ b/spec/features/merchants/items/merchant_item_index_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'when I visit /merchants/items' do
     end
     it 'I see a link to add a new item' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
-      visit merchant_items_path
+      visit dashboard_items_path
 
       expect(page).to have_link("Add a new item")
     end
@@ -21,7 +21,7 @@ RSpec.describe 'when I visit /merchants/items' do
     it 'I see each item I have already added to the system' do
       other_merchant_item = create(:item)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
-      visit merchant_items_path
+      visit dashboard_items_path
 
 
       @merchant.items.each do |item|
@@ -38,7 +38,7 @@ RSpec.describe 'when I visit /merchants/items' do
 
     it 'I see a link to edit each of my items' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
-      visit merchant_items_path
+      visit dashboard_items_path
 
       @merchant.items.each do |item|
         within "#item-#{item.id}" do
@@ -49,7 +49,7 @@ RSpec.describe 'when I visit /merchants/items' do
 
     it 'I see a button to delete an unordered item' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
-      visit merchant_items_path
+      visit dashboard_items_path
 
       within "#item-#{@enabled_items.first.id}" do
         expect(page).to have_button("Delete Item")
@@ -61,7 +61,7 @@ RSpec.describe 'when I visit /merchants/items' do
       enabled_ordered_item.update(item: @enabled_items.first)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
 
-      visit merchant_items_path
+      visit dashboard_items_path
 
       within "#item-#{@enabled_items.first.id}" do
         expect(page).to have_button("Disable Item")
@@ -73,7 +73,7 @@ RSpec.describe 'when I visit /merchants/items' do
       disabled_ordered_item.update(item: @disabled_item)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
 
-      visit merchant_items_path
+      visit dashboard_items_path
 
       within "#item-#{@disabled_item.id}" do
         expect(page).to have_button("Enable Item")

--- a/spec/features/merchants/merchant_index_page_spec.rb
+++ b/spec/features/merchants/merchant_index_page_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'when I visit the merchant index page' do
         click_button 'Disable'
       end
 
-      expect(page).to have_content "#{@active_merchants.first.name} is now disabled."
+      expect(page).to have_content "You have disabled a user"
 
       within "#merchant-#{@active_merchants.first.id}" do
         expect(page).to have_button('Enable')
@@ -119,7 +119,7 @@ RSpec.describe 'when I visit the merchant index page' do
         click_button 'Enable'
       end
 
-      expect(page).to have_content "#{inactive_merchant.name} is now enabled."
+      expect(page).to have_content "You have enabled a user"
 
       within "#merchant-#{inactive_merchant.id}" do
         expect(page).to have_button('Disable')
@@ -129,7 +129,7 @@ RSpec.describe 'when I visit the merchant index page' do
 
       login_as(inactive_merchant)
 
-      expect(page).to have_content 'Invalid email and/or password'
+      expect(page).to have_content("You are now logged in")
     end
   end
 end

--- a/spec/features/merchants/merchant_index_page_spec.rb
+++ b/spec/features/merchants/merchant_index_page_spec.rb
@@ -48,10 +48,13 @@ RSpec.describe 'when I visit the merchant index page' do
   end
 
   context 'as an admin' do
+    before :each do
+      @admin = build(:admin)
+      @admin.save
+    end
+
     it 'next to each active merchants name I see a button to disable them' do
-      admin = build(:admin)
-      admin.save
-      login_as(admin)
+      login_as(@admin)
       visit merchants_path
 
       @active_merchants.each do |merchant|
@@ -64,9 +67,7 @@ RSpec.describe 'when I visit the merchant index page' do
     it 'next to each inactive_merchant I see a button to enable them' do
       inactive_merchant = build(:inactive_merchant)
       inactive_merchant.save
-      admin = build(:admin)
-      admin.save
-      login_as(admin)
+      login_as(@admin)
       visit merchants_path
 
       within "#merchant-#{inactive_merchant.id}" do
@@ -75,9 +76,7 @@ RSpec.describe 'when I visit the merchant index page' do
     end
 
     it 'each merchant name is a link to their dashboard' do
-      admin = build(:admin)
-      admin.save
-      login_as(admin)
+      login_as(@admin)
       visit merchants_path
 
       @active_merchants.each do |merchant|
@@ -85,6 +84,52 @@ RSpec.describe 'when I visit the merchant index page' do
           expect(page).to have_link(merchant.name)
         end
       end
+    end
+
+    it 'I can click the button to disable an enabled merchant' do
+      login_as(@admin)
+
+      visit merchants_path
+
+      within "#merchant-#{@active_merchants.first.id}" do
+        click_button 'Disable'
+      end
+
+      expect(page).to have_content "#{@active_merchants.first.name} is now disabled."
+
+      within "#merchant-#{@active_merchants.first.id}" do
+        expect(page).to have_button('Enable')
+      end
+
+      click_link 'Logout'
+
+      login_as(@active_merchants.first)
+
+      expect(page).to have_content 'Invalid email and/or password'
+    end
+
+    it 'I can click a link to enable a disabled merchant' do
+      inactive_merchant = build(:inactive_merchant)
+      inactive_merchant.save
+      login_as(@admin)
+
+      visit merchants_path
+
+      within "#merchant-#{inactive_merchant.id}" do
+        click_button 'Enable'
+      end
+
+      expect(page).to have_content "#{inactive_merchant.name} is now enabled."
+
+      within "#merchant-#{inactive_merchant.id}" do
+        expect(page).to have_button('Disable')
+      end
+
+      click_link 'Logout'
+
+      login_as(inactive_merchant)
+
+      expect(page).to have_content 'Invalid email and/or password'
     end
   end
 end


### PR DESCRIPTION
- Adds tests for admin ability to enable and disable merchant users from '/merchants' route
- Adds logic to admin/users controller to support alternate redirect for merchants and regular users
- closes #20 
- closes #21 
