### PR TITLE
User profile orders link#40

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,2 +1,4 @@
 class Admin::MerchantsController < Admin::BaseController
+  def show
+  end
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,0 +1,2 @@
+class Admin::MerchantsController < Admin::BaseController
+end

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -4,3 +4,4 @@
 <p>City: <%=  @user.city %> </p>
 <p>State: <%= @user.state %> </p>
 <p>Zip code: <%= @user.zipcode %> </p>
+<%= link_to "See My Orders", profile_orders_path %>

--- a/spec/features/admins/admin_sees_merchant_dashboard_spec.rb
+++ b/spec/features/admins/admin_sees_merchant_dashboard_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'admin views merchant dashboard' do
+  describe 'as an admin when Im on the merchant index page and I click on a merchant name' do
+    before :each do
+      @merchant = create(:merchant)
+      admin = create(:admin)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    end
+
+    it 'takes me to the route admin/merchants/:id' do
+      visit merchants_path
+
+      click_on "#{@merchant.name}"
+
+      expect(current_path).to eq(admin_merchant_path(@merchant))
+    end
+
+    # it 'shows the same info the merchant sees' do
+    #
+    #   visit admin_user_path(user)
+    #
+    #   expect(page).to have_content("Name: #{user.name}")
+    #   expect(page).to have_content("Email: #{user.email}")
+    #   expect(page).to have_content("Address: #{user.address}")
+    #   expect(page).to have_content("City: #{user.city}")
+    #   expect(page).to have_content("State: #{user.state}")
+    #   expect(page).to have_content("Zip code: #{user.zipcode}")
+    #
+    #   expect(page).to_not have_content(user.password)
+    # end
+  end
+end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'User profile page' do
       @user = build(:user)
       @user.save
     end
+
     describe 'when I visit my profile' do
       it 'I see all of my profile data except for my password' do
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
@@ -55,7 +56,6 @@ RSpec.describe 'User profile page' do
           expect(current_path).to eq(profile_path)
           expect(page).to have_content("Your profile has been updated")
           expect(page).to have_content("Name: chris123")
-
         end
 
         it 'does not allow me to enter another user\'s email ' do
@@ -71,6 +71,16 @@ RSpec.describe 'User profile page' do
 
           expect(page).to have_content('That email is already registered.')
         end
+      end
+
+      it 'also shows me a link to my orders on my profile page' do
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+        visit profile_path
+
+        click_on "See My Orders"
+
+        expect(current_path).to eq(profile_orders_path)
       end
     end
   end


### PR DESCRIPTION
As a registered user
When I visit my Profile page
And I have orders placed in the system
Then I see a link to my Profile Orders page

This link is also in the nav bar, but this new link is for admins.

closes #40 