### PR TITLE
Merchant edit item #12

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -18,6 +18,20 @@ class Merchant::ItemsController < Merchant::BaseController
     end
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      flash[:success] = "Your item has been successfully updated."
+      redirect_to dashboard_items_path
+    else
+      flash[:danger] = "There are problems with the provided information."
+      render :edit
+    end
+  end
 
   def enable
     Item.find(params[:id]).update(disabled: false)
@@ -36,9 +50,9 @@ class Merchant::ItemsController < Merchant::BaseController
     flash[:danger] = "Item ##{params[:id]} has been deleted."
     redirect_to dashboard_items_path
   end
-  
+
    private
-  
+
    def item_params
     params[:item][:image] = "https://via.placeholder.com/200x300?text=LittleShop" if params[:item][:image] == ""
     params.require(:item).permit(:name, :description, :image, :price, :quantity)

--- a/app/views/merchant/items/_errors.html.erb
+++ b/app/views/merchant/items/_errors.html.erb
@@ -1,0 +1,7 @@
+<% if @item.errors %>
+<ul id="errors">
+  <% @item.errors.full_messages.each do |message| %>
+  <li><%= message %></li>
+  <% end %>
+</ul>
+<% end %>

--- a/app/views/merchant/items/_item.html.erb
+++ b/app/views/merchant/items/_item.html.erb
@@ -1,4 +1,3 @@
-<%= form_for @item, :url => {:controller => 'merchant/items', :action => 'create'} do |f| %>
 <div class="form-group">
   <%= f.label :name %>
   <%= f.text_field :name, class: "form-control" %>
@@ -21,5 +20,3 @@
 </div>
 
 <%= f.submit 'Submit', class: 'btn btn-primary' %>
-
-<% end %>

--- a/app/views/merchant/items/edit.html.erb
+++ b/app/views/merchant/items/edit.html.erb
@@ -1,4 +1,4 @@
 <%= render partial: 'merchant/items/errors' %>
-<%= form_for @item, :url => {:controller => 'merchant/items', :action => 'create'} do |f| %>
+<%= form_for @item, :url => {:controller => 'merchant/items', :action => 'update'} do |f| %>
 <%= render partial: 'merchant/items/item', locals: {:f => f} %>
 <% end %>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -11,7 +11,7 @@
       <ul class="list-group list-group-flush">
         <li class="list-group-item">Price: <%= number_to_currency(item.price) %></li>
         <li class="list-group-item">Current Stock: <%= item.quantity %></li>
-        <li class="list-group-item"><%= link_to "Edit Item", edit_merchant_item_path(item) %></li>
+        <li class="list-group-item"><%= link_to "Edit Item", edit_dashboard_item_path(item) %></li>
         <li class="list-group-item"><%= button_to "Delete Item", merchant_item_path(item), method: :delete if !item.ordered? %>
         <%= button_to "Enable Item", merchant_enable_item_path(item), method: :put if item.ordered? && item.disabled %>
         <%= button_to "Disable Item", merchant_disable_item_path(item), method: :put if item.ordered? && !item.disabled %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,11 +16,11 @@ Rails.application.routes.draw do
 
   scope :dashboard, module: :merchant, as: :dashboard do
     get '/', to: 'users#show'
-    resources :items, only: [:index, :new]
+    resources :items, only: [:index, :new, :edit, :update]
   end
 
   namespace :merchant do
-    resources :items, except: [:show, :index, :new]
+    resources :items, except: [:show, :index, :new, :edit, :update]
 
     put '/items/:id/enable', to: 'items#enable', as: :enable_item
     put '/items/:id/disable', to: 'items#disable', as: :disable_item

--- a/spec/features/merchants/items/merchant_edit_item_spec.rb
+++ b/spec/features/merchants/items/merchant_edit_item_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe 'Editing an item' do
+  context 'as a merchant' do
+    before :each do
+      @merchant = create(:merchant)
+      @item = create(:item)
+      @merchant.items << @item
+      login_as(@merchant)
+
+      visit dashboard_items_path
+    end
+
+    it 'I can edit an item from my items index' do
+      within "#item-#{@item.id}" do
+        click_link 'Edit Item'
+      end
+
+      fill_in :Name, with: 'New Name'
+      click_button :Submit
+
+      within "#item-#{@item.id}" do
+        expect(page).to have_content('New Name')
+      end
+    end
+
+    describe 'I am unable to edit an item when' do
+      before :each do
+        visit edit_merchant_item_path(@item)
+        fill_in :Name, with: @item.name
+        fill_in :Description, with: @item.description
+        fill_in :Quantity, with: @item.quantity
+        fill_in :Price, with: @item.price
+      end
+
+      it "I remove the name" do
+        fill_in :Name, with: ""
+        click_button :Submit
+        expect(page).to have_content("There are problems with the provided information.")
+        expect(page).to have_content("Name can't be blank")
+      end
+
+      it "I remove the description" do
+        fill_in :Description, with: ""
+        click_button :Submit
+        expect(page).to have_content("There are problems with the provided information.")
+        expect(page).to have_content("Description can't be blank")
+      end
+
+      it "I remove the price" do
+        fill_in :Price, with: ""
+        click_button 'Submit'
+        expect(page).to have_content("There are problems with the provided information.")
+        expect(page).to have_content("Price can't be blank")
+      end
+
+      it "I try and enter a negative value for the price" do
+        fill_in :Price, with: "-999.99"
+        click_button 'Submit'
+        expect(page).to have_content("There are problems with the provided information.")
+        expect(page).to have_content("Price must be greater than or equal to 0")
+      end
+
+      it "I remove the quantity" do
+        fill_in :Quantity, with: ""
+        click_button 'Submit'
+        expect(page).to have_content("There are problems with the provided information.")
+        expect(page).to have_content("Quantity can't be blank")
+      end
+
+      it "I enter a quantity below zero" do
+        fill_in :Quantity, with: "-990"
+        click_button 'Submit'
+        expect(page).to have_content("There are problems with the provided information.")
+        expect(page).to have_content("Quantity must be greater than or equal to 0")
+      end
+    end
+  end
+end

--- a/spec/features/merchants/items/merchant_edit_item_spec.rb
+++ b/spec/features/merchants/items/merchant_edit_item_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Editing an item' do
 
     describe 'I am unable to edit an item when' do
       before :each do
-        visit edit_merchant_item_path(@item)
+        visit edit_dashboard_item_path(@item)
         fill_in :Name, with: @item.name
         fill_in :Description, with: @item.description
         fill_in :Quantity, with: @item.quantity


### PR DESCRIPTION
- Adds tests for merchant's ability to edit items
- Updates routing to match user story specifications (/dashboard/items/:id/edit)
- Moves form_for opening tag outside of partial and in to views for new and edit, passing local variable 'f' to partial views for form
- Adds ability for merchant to update items and flash messaging
- Adds error messaging and logic for improper information present in item update form
- closes #12 
- closes #11 