### PR TITLE
Downgrade Merchant to Registered User

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -4,4 +4,14 @@ class Admin::MerchantsController < Admin::BaseController
     @orders = Order.pending_orders(@merchant)
     redirect_to admin_user_path(@merchant) if @merchant.registered?
   end
+
+  def downgrade
+    @merchant = User.find(params[:id])
+    @merchant.items.each do |item|
+      item.update(disabled: 'true')
+    end
+    @merchant.update(role: 'registered')
+    flash[:primary] = 'You have downgraded a merchant'
+    redirect_to admin_user_path(@merchant)
+  end
 end

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,5 +1,6 @@
 <section>
   <h1>Your Dashboard</h1>
+  <%= link_to 'Downgrade', admin_downgrade_merchant_path(@merchant), method: :put  %>
   <article class="user-info">
     <p>Name: <%= @merchant.name %> </p>
     <p>Email: <%= @merchant.email %> </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,8 +41,9 @@ Rails.application.routes.draw do
     put '/users/:id/enable', to: 'users#enable', as: :enable_user
     put '/users/:id/disable', to: 'users#disable', as: :disable_user
     put 'users/:id/upgrade', to: 'users#upgrade', as: :upgrade_user
+    put '/merchant/:id/downgrade', to: 'merchants#downgrade', as: :downgrade_merchant
     get '/dashboard', to: 'dashboard#show'
-    resources :merchants, only: [:show] do
+    resources :merchants, only: [:show, :update] do
       resources :items, except: :show
       put '/items/:id/enable', to: 'items#enable', as: :enable_item
       put '/items/:id/disable', to: 'items#disable', as: :disable_item

--- a/spec/features/admins/users_show_spec.rb
+++ b/spec/features/admins/users_show_spec.rb
@@ -2,27 +2,59 @@ require 'rails_helper'
 
 RSpec.describe 'Admin user show page' do
   context 'as an admin' do
+    before :each do
+      @item = create(:item)
+      @merchant = create(:merchant, items: [@item])
+      @user = create(:user)
+      @admin = create(:admin)
+    end
     describe 'when I visit a user\'s profile page' do
       it 'I can upgrade that user to become a merchant' do
-        user = create(:user)
-        admin = create(:admin)
-
-        login_as(user)
+        login_as(@user)
 
         expect(current_path).to eq(profile_path)
 
         click_link('Logout')
-        login_as(admin)
-        visit admin_user_path(user)
+        login_as(@admin)
+        visit admin_user_path(@user)
         click_link 'Upgrade'
 
-        expect(current_path).to eq(admin_merchant_path(user))
+        expect(current_path).to eq(admin_merchant_path(@user))
         expect(page).to have_content("You have upgraded a user")
 
         click_link('Logout')
-        login_as(user)
+        login_as(@user)
 
         expect(current_path).to eq(dashboard_path)
+      end
+    end
+
+    describe 'when I visit a merchant\'s dashboard page' do
+      it 'I can downgrade a merchant to a regular user' do
+        login_as(@merchant)
+
+        expect(current_path).to eq(dashboard_path)
+
+        click_link('Items')
+
+        expect(page).to have_content(@item.name)
+
+        click_link('Logout')
+        login_as(@admin)
+        visit admin_user_path(@merchant)
+        click_link 'Downgrade'
+
+        expect(current_path).to eq(admin_user_path(@merchant))
+        expect(page).to have_content("You have downgraded a merchant")
+
+        click_link('Logout')
+        login_as(@merchant)
+
+        expect(current_path).to eq(profile_path)
+
+        click_link('Items')
+
+        expect(page).to_not have_content(@item.name)
       end
     end
   end


### PR DESCRIPTION
- Added downgrade route and action for admin merchants controller
- Added link to downgrade merchant on admin merchants show page
- Added functionality to disable a merchant's items when they are downgraded
- User Story 44 complete, closes #27

Here's the functionality for downgrading merchants to regular users. It's almost exactly the same as the upgrade function for users, but it also disables all of the merchant's items at the same time. I disabled the items by iterating through the merchant.items and updating their status with Ruby, but if you think there's a better way to do this let me know.