### PR TITLE
Merchant fulfills part of order#7

### DIFF
--- a/app/controllers/merchant/orders_controller.rb
+++ b/app/controllers/merchant/orders_controller.rb
@@ -2,15 +2,12 @@ class Merchant::OrdersController < Merchant::BaseController
   def show
     @order = Order.find(params[:id])
     @customer = @order.user
-    @items = Item.joins(:orders)
-                  .where(user: current_user.id)
-                  .group(:id)
+    @order_items = @order.order_items.joins(:item)
+                  .select("order_items.*,items.name as name, items.image as image")
+                  .where(items: {user: current_user.id})
+  end
 
-    @items_and_quantities = Hash.new
-
-    @items.each do |item|
-      @items_and_quantities[item] = item.order_items.where(order_id: @order.id).sum(:quantity)
-    end
-
+  def update
+    redirect_to merchant_order_path(Order.find(params[:id]))
   end
 end

--- a/app/controllers/merchant/orders_controller.rb
+++ b/app/controllers/merchant/orders_controller.rb
@@ -8,6 +8,12 @@ class Merchant::OrdersController < Merchant::BaseController
   end
 
   def update
+    order_item = OrderItem.find(params[:order_item])
+    order_item.update(fulfilled: true)
+    item = Item.find(order_item.item_id)
+    new_quantity = item.quantity - order_item.quantity
+    item.update(quantity: new_quantity)
+    flash[:success] = "You have fulfilled #{item.name} from order ##{order_item.order_id}"
     redirect_to merchant_order_path(Order.find(params[:id]))
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -48,12 +48,14 @@ class Item < ApplicationRecord
   end
 
   def average_fulfillment_time
-    if order_items.count > 0
+    if (order_items.count > 0) && (order_items.where({fulfilled: true})).count > 0
       Item.joins(:order_items)
           .where(id: self.id, order_items: {fulfilled: true})
           .select("avg(order_items.updated_at - order_items.created_at) as fulfillment_time")
           .group(:id)[0]
           .fulfillment_time
+    elsif order_items.count > 0
+      "This item has not been fulfilled"
     else
       "Never been ordered"
     end

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -17,7 +17,8 @@
   <li> <img class="img-responsive" src=<%= order_item.image %> > </li>
   <li>Price:  <%= number_to_currency(order_item.unit_price)%></li>
   <li>Quantity: <%= order_item.quantity %> </li>
-  <li><%= button_to "Fulfill", merchant_order_path(@order), method: :put unless order_item.fulfilled? %></li>
+  <li><%= button_to "Fulfill", merchant_order_path(@order, order_item: order_item), method: :put unless order_item.fulfilled %></li>
+  <li><%= "Item Fulfilled" if order_item.fulfilled %></li>
   </ul>
   <% end  %>
 

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -10,13 +10,14 @@
 <section class="my-items">
   <h5>Items:</h5>
 
-  <% @items.each do |item| %>
-  <ul id="item-<%= item.id %>">
+  <% @order_items.each do |order_item| %>
+  <ul id="item-<%= order_item.item_id %>">
 
-  <li> <%=link_to item.name, item_path(item)%>  </li>
-  <li> <img class="img-responsive" src=<%= item.image %> > </li>
-  <li>Price:  <%= number_to_currency(item.price)%></li>
-  <li>Quantity: <%= @items_and_quantities[item] %> </li>
+  <li> <%=link_to order_item.name, item_path(order_item.item_id)%>  </li>
+  <li> <img class="img-responsive" src=<%= order_item.image %> > </li>
+  <li>Price:  <%= number_to_currency(order_item.unit_price)%></li>
+  <li>Quantity: <%= order_item.quantity %> </li>
+  <li><%= button_to "Fulfill", merchant_order_path(@order), method: :put unless order_item.fulfilled? %></li>
   </ul>
   <% end  %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
   end
 
   scope :dashboard, as: :merchant, module: :merchant do
-    resources :orders, only: :show
+    resources :orders, only: [:show, :update]
   end
 
   namespace :admin do

--- a/spec/factories/order_item.rb
+++ b/spec/factories/order_item.rb
@@ -3,10 +3,10 @@ FactoryBot.define do
     order
     item
     sequence(:quantity) { |n| ("#{n}".to_i+1)*2 }
-    sequence(:unit_price) { |n| ("#{n}".to_i+1)*1.5 }
+    unit_price {item.price}
     fulfilled { false }
   end
-  
+
   factory :fulfilled_order_item, parent: :order_item do
     fulfilled { true }
   end

--- a/spec/features/merchants/merchant_sees_order_spec.rb
+++ b/spec/features/merchants/merchant_sees_order_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "When I visit an order show page from my dashboard" do
     @merchant = create(:merchant)
     @customer = create(:user, address: "123 Main St", city: "Denver", state: "CO", zipcode: 80302)
     @other_merchant = create(:merchant)
-    @item_1 = create(:item, user: @merchant)
+    @item_1 = create(:item, user: @merchant, quantity: 11)
     @item_2 = create(:item, user: @merchant)
     @item_3 = create(:item, user: @merchant)
     @item_4 = create(:item, user: @merchant)
@@ -26,7 +26,6 @@ RSpec.describe "When I visit an order show page from my dashboard" do
   end
 
   context "as a merchant" do
-
     it "I see customer/s name, address" do
       login_as(@merchant)
       visit dashboard_path
@@ -117,6 +116,31 @@ RSpec.describe "When I visit an order show page from my dashboard" do
       end
     end
 
-  end
+    describe 'when I visit an order show page from my dashboard' do
+      it 'allows me to to fulfill an unfulfilled item in that order' do
+        login_as(@merchant)
 
+        visit dashboard_path
+
+        click_on "#{@order_1.id}"
+
+        expect(current_path).to eq(merchant_order_path(@order_1))
+
+        within "#item-#{@item_1.id}" do
+          expect(page).to have_content("Quantity: 11")
+          click_button "Fulfill"
+        end
+
+        expect(current_path).to eq(merchant_order_path(@order_1))
+
+        within "#item-#{@item_1.id}" do
+          expect(page).to_not have_button("Fulfill")
+          expect(page).to have_content("Quantity: 2")
+          expect(page).to have_content("Item Fulfilled")
+        end
+
+        expect(page).to have_content("You have fulfilled #{item_1.name} from order ##{@order_1.id}")
+      end
+    end
+  end
 end

--- a/spec/features/merchants/merchant_sees_order_spec.rb
+++ b/spec/features/merchants/merchant_sees_order_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "When I visit an order show page from my dashboard" do
 
         expect(Item.find(@item_1.id).quantity).to eq(2)
 
-        expect(page).to have_content("You have fulfilled #{item_1.name} from order ##{@order_1.id}")
+        expect(page).to have_content("You have fulfilled #{@item_1.name} from order ##{@order_1.id}")
       end
     end
   end

--- a/spec/features/merchants/merchant_sees_order_spec.rb
+++ b/spec/features/merchants/merchant_sees_order_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "When I visit an order show page from my dashboard" do
     @merchant = create(:merchant)
     @customer = create(:user, address: "123 Main St", city: "Denver", state: "CO", zipcode: 80302)
     @other_merchant = create(:merchant)
-    @item_1 = create(:item, user: @merchant, quantity: 11)
+    @item_1 = create(:item, user: @merchant, price: 24.0, quantity: 11)
     @item_2 = create(:item, user: @merchant)
     @item_3 = create(:item, user: @merchant)
     @item_4 = create(:item, user: @merchant)
@@ -90,8 +90,8 @@ RSpec.describe "When I visit an order show page from my dashboard" do
       within "#item-#{@item_1.id}" do
         expect(page).to have_content(@item_1.name)
         expect(page).to have_css("img[src*='#{@item_1.image}']")
-        expect(page).to have_content(@item_1.price)
-        expect(page).to have_content("Quantity: 9")
+        expect(page).to have_content("$24.00")
+        expect(page).to have_content(@order_item_1.quantity)
       end
 
       within "#item-#{@item_2.id}" do
@@ -104,7 +104,7 @@ RSpec.describe "When I visit an order show page from my dashboard" do
       within "#item-#{@item_3.id}" do
         expect(page).to have_content(@item_3.name)
         expect(page).to have_css("img[src*='#{@item_3.image}']")
-        expect(page).to have_content(@item_3.price)
+        expect(page).to have_content(@order_item_3.unit_price)
         expect(page).to have_content("Quantity: 7")
       end
 
@@ -126,8 +126,9 @@ RSpec.describe "When I visit an order show page from my dashboard" do
 
         expect(current_path).to eq(merchant_order_path(@order_1))
 
+        expect(Item.find(@item_1.id).quantity).to eq(11)
+
         within "#item-#{@item_1.id}" do
-          expect(page).to have_content("Quantity: 11")
           click_button "Fulfill"
         end
 
@@ -135,9 +136,10 @@ RSpec.describe "When I visit an order show page from my dashboard" do
 
         within "#item-#{@item_1.id}" do
           expect(page).to_not have_button("Fulfill")
-          expect(page).to have_content("Quantity: 2")
           expect(page).to have_content("Item Fulfilled")
         end
+
+        expect(Item.find(@item_1.id).quantity).to eq(2)
 
         expect(page).to have_content("You have fulfilled #{item_1.name} from order ##{@order_1.id}")
       end

--- a/spec/features/merchants/merchant_sees_order_spec.rb
+++ b/spec/features/merchants/merchant_sees_order_spec.rb
@@ -61,24 +61,25 @@ RSpec.describe "When I visit an order show page from my dashboard" do
       expect(page).to have_link(@item_3.name)
       expect(page).to have_link(@item_4.name)
 
-      #
-      # click_link(@item_1.name)
-      # expect(current_path).to eq(item_path(@item_1))
-      #
-      # visit dashboard_path
-      # click_link @order_1.id
-      # click_link(@item_2.name)
-      # expect(current_path).to eq(item_path(@item_2))
-      #
-      # visit dashboard_path
-      # click_link @order_1.id
-      # click_link(@item_3.name)
-      # expect(current_path).to eq(item_path(@item_3))
-      #
-      # visit dashboard_path
-      # click_link @order_1.id
-      # click_link(@item_4.name)
-      # expect(current_path).to eq(item_path(@item_4))
+
+      click_link(@item_1.name)
+      expect(current_path).to eq(item_path(@item_1))
+
+      visit dashboard_path
+      click_link @order_1.id
+      click_link(@item_2.name)
+      expect(current_path).to eq(item_path(@item_2))
+
+      visit dashboard_path
+      click_link @order_1.id
+      click_link(@item_3.name)
+      expect(current_path).to eq(item_path(@item_3))
+      expect(page).to have_content("This item has not been fulfilled")
+
+      visit dashboard_path
+      click_link @order_1.id
+      click_link(@item_4.name)
+      expect(current_path).to eq(item_path(@item_4))
     end
 
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -38,15 +38,18 @@ RSpec.describe Item, type: :model do
       merchant.save
       item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 20.987, quantity: 1)
       item_2 = merchant.items.create(name: "Thing 2", description: "It's another thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 2.0, quantity: 2)
+      item_3 = merchant.items.create(name: "Thing 3", description: "It's all thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 3.0, quantity: 5)
       user = build(:user)
       user.save
       order = user.orders.create
       order_2 = user.orders.create
       OrderItem.create(item: item_1, order: order, quantity: 2, unit_price: item_1.price, created_at: 5.seconds.ago, updated_at: 1.second.ago, fulfilled: true)
       OrderItem.create(item: item_1, order: order_2, quantity: 3, unit_price: item_1.price, created_at: 8.seconds.ago, updated_at: 6.second.ago, fulfilled: true)
+      OrderItem.create(item: item_3, order: order_2, quantity: 3, unit_price: item_3.price, created_at: 8.seconds.ago)
 
       expect(item_1.average_fulfillment_time[0..7]).to eq("00:00:03")
       expect(item_2.average_fulfillment_time).to eq("Never been ordered")
+      expect(item_3.average_fulfillment_time).to eq("This item has not been fulfilled")
     end
 
     it '.ordered?' do


### PR DESCRIPTION
As a merchant
When I visit an order show page from my dashboard
For each item of mine in the order
If the user's desired quantity is equal to or less than my current inventory quantity for that item
And I have not already "fulfilled" that item:
- Then I see a button or link to "fulfill" that item
- When I click on that link or button I am returned to the order show page
- I see the item is now fulfilled
- I also see a flash message indicating that I have fulfilled that item
- My inventory quantity is permanently reduced by the user's desired quantity

If I have already fulfilled this item, I see text indicating such.

closes #7 