### PR TITLE
Removes checkout button from cart show page for visitors and users with an empty cart

### DIFF
--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -39,7 +39,7 @@
     </div>
     <div>
       <div class="col-xs-2">
-        <%= button_to "Checkout", profile_orders_path, class: "btn btn-success btn-block" if current_user && current_user.registered? && session[:cart] != nil && session[:cart] != {} %>
+        <%= button_to "Checkout", profile_orders_path, class: "btn btn-success btn-block" if current_user && @cart.contents.empty? == false %>
       </div>
     </div>
   </div>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -39,7 +39,7 @@
     </div>
     <div>
       <div class="col-xs-2">
-        <%= button_to "Checkout", profile_orders_path, class: "btn btn-success btn-block" if current_user && @cart.contents.empty? == false %>
+        <%= button_to "Checkout", profile_orders_path, class: "btn btn-success btn-block" if current_user && !@cart.contents.empty?%>
       </div>
     </div>
   </div>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -22,7 +22,7 @@
     </div>
     <hr>
     <% end %>
-    
+
     <div class="row">
       <div class="text-center">
       </div>
@@ -39,7 +39,7 @@
     </div>
     <div>
       <div class="col-xs-2">
-        <%= button_to "Checkout", profile_orders_path, class: "btn btn-success btn-block" %>
+        <%= button_to "Checkout", profile_orders_path, class: "btn btn-success btn-block" if current_user && current_user.registered? && session[:cart] != nil && session[:cart] != {} %>
       </div>
     </div>
   </div>

--- a/spec/features/cart_show_spec.rb
+++ b/spec/features/cart_show_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe 'cart show page', type: :feature do
   end
 
   context "as a visitor" do
+    it 'I don\'t see a button to checkout' do
+      visit root_path
+      click_on "Cart"
+
+      expect(page).to_not have_button('Checkout')
+    end
+
     describe "when I have items in my cart" do
       describe "and I visit the cart show page" do
         it "I see a message telling me to register or login in order to checkout" do
@@ -220,22 +227,38 @@ RSpec.describe 'cart show page', type: :feature do
   end
 
   context 'as a registered user' do
+    before :each do
+      @user = create(:user)
+      @merchant = create(:merchant)
+      @item_1 = @merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 5.0, quantity: 1)
+      @item_2 = create(:item, user: @merchant)
+    end
+    describe 'when my cart is empty' do
+      it 'I don\'t see a button to checkout' do
+        login_as(@user)
+        click_link 'Cart'
+
+        expect(page).to_not have_button('Checkout')
+
+        visit item_path(@item_1)
+        click_on "Add to Shopping Cart"
+        click_link 'Cart'
+        click_button 'Empty Cart'
+        expect(page).to_not have_button('Checkout')
+      end
+    end
     describe 'when I add items to my cart' do
       it 'and i visit my cart I can check out' do
-        user = create(:user)
-        merchant = create(:merchant)
-        item_1 = merchant.items.create(name: "Thing 1", description: "It's a thing", image: "https://upload.wikimedia.org/wikipedia/en/5/53/Snoopy_Peanuts.png", price: 5.0, quantity: 1)
-        item_2 = create(:item, user: merchant)
 
-        login_as(user)
+        login_as(@user)
 
-        visit item_path(item_1)
+        visit item_path(@item_1)
         click_on "Add to Shopping Cart"
 
-        visit item_path(item_1)
+        visit item_path(@item_1)
         click_on "Add to Shopping Cart"
 
-        visit item_path(item_2)
+        visit item_path(@item_2)
         click_on "Add to Shopping Cart"
 
         click_on "Cart"

--- a/spec/features/merchants/merchant_index_page_spec.rb
+++ b/spec/features/merchants/merchant_index_page_spec.rb
@@ -220,7 +220,6 @@ RSpec.describe 'when I visit the merchant index page' do
       create(:order_item, order: order_14, item: item_1, fulfilled: true)
 
       visit merchants_path
-      save_and_open_page
 
       within '#statistics' do
         within '#top-states' do


### PR DESCRIPTION
- Added logic to checkout button on cart show page to not render if the user is a visitor or has an empty cart
- Wrote tests for user and visitor functionality
- Removed leftover save_and_open_page from master
- Closes #151 

The logic on the button is a little long, but it achieves the desired result. I tried doing the same logic with an 'unless', but it was about the same length.