### PR TITLE
Changes item edit form to accept prices like 00.01

### DIFF
--- a/app/views/merchant/items/_item.html.erb
+++ b/app/views/merchant/items/_item.html.erb
@@ -12,7 +12,7 @@
 </div>
 <div class="form-group">
   <%= f.label :price %>
-  <%= f.number_field :price, class: "form-control" %>
+  <%= f.number_field :price, step: 0.01, class: "form-control" %>
 </div>
 <div class="form-group">
   <%= f.label :quantity %>

--- a/spec/features/merchants/items/new_merchant_item_spec.rb
+++ b/spec/features/merchants/items/new_merchant_item_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'adding a new item' do
   context 'as a merchant' do
     before :each do
       @merchant = create(:merchant)
-      @valid_item = build(:item)
+      @valid_item = build(:item, price: 100.01)
       @invalid_item = build(:item)
     end
 


### PR DESCRIPTION
Added a 'step' parameter for the item price field in item new and edit forms. This allows us to put in values like $100.01 instead of just 100.